### PR TITLE
Add user() and planSettings() endpoint support

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@ Repository: [jpry/ynab-sdk-php](https://github.com/JPry/ynab-sdk-php)
 ## Highlights
 
 - Namespace root: `JPry\\YNAB\\`
-- Typed resources for plans, accounts, categories, payees, and transactions
-- Endpoint-by-name client methods (`plans()`, `transactions()`, etc.)
+- Typed resources for users, plans, plan settings, accounts, categories, payees, and transactions
+- Endpoint-by-name client methods (`user()`, `plans()`, `planSettings()`, `transactions()`, etc.)
 - Structured YNAB errors (`error.id`, `error.name`, `error.detail`)
 - Supports API key auth and OAuth token auth
 - Uses PSR-7/PSR-18 HTTP contracts; any codebase can provide its own sender by implementing `JPry\\YNAB\\Http\\RequestSender`
@@ -40,7 +40,9 @@ $config = new ClientConfig(
 );
 
 $client = YnabClient::withApiKey('your-api-key', config: $config);
+$user = $client->user();
 $plans = $client->plans();
+$settings = $client->planSettings('plan-id');
 $transactions = $client->transactions('plan-id', ['since_date' => '2026-01-01']);
 ```
 

--- a/src/Client/YnabClient.php
+++ b/src/Client/YnabClient.php
@@ -20,8 +20,10 @@ use JPry\YNAB\Model\Budget;
 use JPry\YNAB\Model\Category;
 use JPry\YNAB\Model\Payee;
 use JPry\YNAB\Model\Plan;
+use JPry\YNAB\Model\PlanSettings;
 use JPry\YNAB\Model\ResourceCollection;
 use JPry\YNAB\Model\Transaction;
+use JPry\YNAB\Model\User;
 use Psr\Http\Message\ResponseInterface;
 
 final readonly class YnabClient
@@ -88,6 +90,18 @@ final readonly class YnabClient
 		$default = $this->firstArrayByKeys($data, ['plan', 'budget']);
 
 		return $default === null ? null : Plan::fromArray($default);
+	}
+
+	public function user(): ?User
+	{
+		$data = $this->get('/user');
+		return is_array($data['user'] ?? null) ? User::fromArray($data['user']) : null;
+	}
+
+	public function planSettings(string $planId): ?PlanSettings
+	{
+		$data = $this->get("/plans/{$planId}/settings");
+		return is_array($data['settings'] ?? null) ? PlanSettings::fromArray($data['settings']) : null;
 	}
 
 	/** @return ResourceCollection<Account> */

--- a/src/Model/PlanSettings.php
+++ b/src/Model/PlanSettings.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JPry\YNAB\Model;
+
+final readonly class PlanSettings
+{
+	public function __construct(
+		public ?string $dateFormat,
+		public ?string $currencyIsoCode,
+		public ?string $currencySymbol,
+		public ?int $currencyDecimalDigits,
+		public ?string $currencyDecimalSeparator,
+		public ?string $currencyGroupSeparator,
+		public ?bool $currencySymbolFirst,
+		public ?bool $currencyDisplaySymbol,
+		public ?string $currencyExampleFormat,
+	) {
+	}
+
+	/** @param array<string,mixed> $row */
+	public static function fromArray(array $row): self
+	{
+		$dateFormat = is_array($row['date_format'] ?? null) ? $row['date_format'] : null;
+		$currencyFormat = is_array($row['currency_format'] ?? null) ? $row['currency_format'] : null;
+
+		return new self(
+			dateFormat: isset($dateFormat['format']) ? (string) $dateFormat['format'] : null,
+			currencyIsoCode: isset($currencyFormat['iso_code']) ? (string) $currencyFormat['iso_code'] : null,
+			currencySymbol: isset($currencyFormat['currency_symbol']) ? (string) $currencyFormat['currency_symbol'] : null,
+			currencyDecimalDigits: array_key_exists('decimal_digits', $currencyFormat ?? []) ? (int) $currencyFormat['decimal_digits'] : null,
+			currencyDecimalSeparator: isset($currencyFormat['decimal_separator']) ? (string) $currencyFormat['decimal_separator'] : null,
+			currencyGroupSeparator: isset($currencyFormat['group_separator']) ? (string) $currencyFormat['group_separator'] : null,
+			currencySymbolFirst: array_key_exists('symbol_first', $currencyFormat ?? []) ? (bool) $currencyFormat['symbol_first'] : null,
+			currencyDisplaySymbol: array_key_exists('display_symbol', $currencyFormat ?? []) ? (bool) $currencyFormat['display_symbol'] : null,
+			currencyExampleFormat: isset($currencyFormat['example_format']) ? (string) $currencyFormat['example_format'] : null,
+		);
+	}
+}

--- a/src/Model/User.php
+++ b/src/Model/User.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JPry\YNAB\Model;
+
+final readonly class User
+{
+	public function __construct(
+		public string $id,
+	) {
+	}
+
+	/** @param array<string,mixed> $row */
+	public static function fromArray(array $row): ?self
+	{
+		$id = trim((string) ($row['id'] ?? ''));
+		if ($id === '') {
+			return null;
+		}
+
+		return new self($id);
+	}
+}

--- a/tests/Integration/YnabClientWorkflowTest.php
+++ b/tests/Integration/YnabClientWorkflowTest.php
@@ -128,3 +128,23 @@ it('keeps budget-named methods and emits deprecation warnings', function () {
 	expect($joinedWarnings)->toContain('budgets() is deprecated');
 	expect($joinedWarnings)->toContain('defaultBudget() is deprecated');
 });
+
+it('retrieves user and plan settings', function () {
+	$sender = new ArrayRequestSender([
+		fn ($request) => new Response(200, [], '{"data":{"user":{"id":"U1"}}}'),
+		fn ($request) => new Response(200, [], '{"data":{"settings":{"date_format":{"format":"YYYY-MM-DD"},"currency_format":{"iso_code":"USD","example_format":"$12,345.67","decimal_digits":2,"decimal_separator":".","symbol_first":true,"group_separator":",","currency_symbol":"$","display_symbol":true}}}}'),
+	]);
+
+	$client = YnabClient::withApiKey('api-key-123', requestSender: $sender);
+
+	$user = $client->user();
+	$settings = $client->planSettings('P1');
+
+	expect($user?->id)->toBe('U1');
+	expect($settings?->dateFormat)->toBe('YYYY-MM-DD');
+	expect($settings?->currencyIsoCode)->toBe('USD');
+	expect($settings?->currencySymbol)->toBe('$');
+
+	expect($sender->requests[0]->getUri()->getPath())->toEndWith('/user');
+	expect($sender->requests[1]->getUri()->getPath())->toEndWith('/plans/P1/settings');
+});

--- a/tests/Unit/ModelMappingTest.php
+++ b/tests/Unit/ModelMappingTest.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 use JPry\YNAB\Model\Budget;
 use JPry\YNAB\Model\Plan;
+use JPry\YNAB\Model\PlanSettings;
 use JPry\YNAB\Model\Transaction;
+use JPry\YNAB\Model\User;
 
 it('maps plan rows into typed objects', function () {
 	$plan = Plan::fromArray(['id' => 'P1', 'name' => 'Main']);
@@ -53,4 +55,41 @@ it('maps transaction rows and keeps raw payload', function () {
 	expect($tx?->id)->toBe('T1');
 	expect($tx?->amount)->toBe(-1234);
 	expect($tx?->raw)->toBe($row);
+});
+
+it('maps user rows into typed objects', function () {
+	$user = User::fromArray(['id' => 'U1']);
+
+	expect($user)->not->toBeNull();
+	expect($user?->id)->toBe('U1');
+});
+
+it('maps plan settings into typed objects', function () {
+	$row = [
+		'date_format' => [
+			'format' => 'YYYY-MM-DD',
+		],
+		'currency_format' => [
+			'iso_code' => 'USD',
+			'currency_symbol' => '$',
+			'decimal_digits' => 2,
+			'decimal_separator' => '.',
+			'group_separator' => ',',
+			'symbol_first' => true,
+			'display_symbol' => true,
+			'example_format' => '$12,345.67',
+		],
+	];
+
+	$settings = PlanSettings::fromArray($row);
+
+	expect($settings->dateFormat)->toBe('YYYY-MM-DD');
+	expect($settings->currencyIsoCode)->toBe('USD');
+	expect($settings->currencySymbol)->toBe('$');
+	expect($settings->currencyDecimalDigits)->toBe(2);
+	expect($settings->currencyDecimalSeparator)->toBe('.');
+	expect($settings->currencyGroupSeparator)->toBe(',');
+	expect($settings->currencySymbolFirst)->toBeTrue();
+	expect($settings->currencyDisplaySymbol)->toBeTrue();
+	expect($settings->currencyExampleFormat)->toBe('$12,345.67');
 });


### PR DESCRIPTION
## Summary
- add `YnabClient::user()` for `GET /user`
- add `YnabClient::planSettings(string $planId)` for `GET /plans/{plan_id}/settings`
- add typed models for the new payloads: `User` and `PlanSettings`
- add integration coverage for endpoint pathing + response mapping
- add unit coverage for new model mappings
- update README highlights and quick-start examples

## Tracking
- Closes #6
- Closes #7
- Part of #4

## Validation
- ./vendor/bin/pest --colors=never