### PR TITLE
Add goal_needs_whole_amount field for API v1.83.0

### DIFF
--- a/src/Model/Mutation/CreateCategoryRequest.php
+++ b/src/Model/Mutation/CreateCategoryRequest.php
@@ -12,6 +12,7 @@ final readonly class CreateCategoryRequest implements RequestModel
 		public ?string $note = null,
 		public ?int $goalTarget = null,
 		public ?string $goalTargetDate = null,
+		public ?bool $goalNeedsWholeAmount = null,
 	) {
 	}
 
@@ -26,6 +27,7 @@ final readonly class CreateCategoryRequest implements RequestModel
 			'note' => $this->note,
 			'goal_target' => $this->goalTarget,
 			'goal_target_date' => $this->goalTargetDate,
+			'goal_needs_whole_amount' => $this->goalNeedsWholeAmount,
 		], fn ($v) => $v !== null);
 
 		return [

--- a/src/Model/Mutation/UpdateCategoryRequest.php
+++ b/src/Model/Mutation/UpdateCategoryRequest.php
@@ -18,6 +18,7 @@ final readonly class UpdateCategoryRequest implements RequestModel, Model
 		public ?string $categoryGroupId = null,
 		public ?int $goalTarget = null,
 		public ?string $goalTargetDate = null,
+		public ?bool $goalNeedsWholeAmount = null,
 	) {
 	}
 
@@ -31,6 +32,7 @@ final readonly class UpdateCategoryRequest implements RequestModel, Model
 				'category_group_id' => $this->categoryGroupId,
 				'goal_target' => $this->goalTarget,
 				'goal_target_date' => $this->goalTargetDate,
+				'goal_needs_whole_amount' => $this->goalNeedsWholeAmount,
 			], fn ($v) => $v !== null),
 		];
 	}

--- a/tests/Unit/MutationSerializationTest.php
+++ b/tests/Unit/MutationSerializationTest.php
@@ -184,6 +184,7 @@ it('UpdateCategoryRequest toArray() wraps data under category key', function () 
 		categoryGroupId: 'CG1',
 		goalTarget: 30000,
 		goalTargetDate: '2026-12-31',
+		goalNeedsWholeAmount: true,
 	);
 
 	$result = $request->toArray();
@@ -195,6 +196,7 @@ it('UpdateCategoryRequest toArray() wraps data under category key', function () 
 		'category_group_id' => 'CG1',
 		'goal_target' => 30000,
 		'goal_target_date' => '2026-12-31',
+		'goal_needs_whole_amount' => true,
 	]);
 });
 
@@ -217,6 +219,7 @@ it('UpdateCategoryRequest toArray() excludes null optional fields inside categor
 	expect($inner)->not->toHaveKey('category_group_id');
 	expect($inner)->not->toHaveKey('goal_target');
 	expect($inner)->not->toHaveKey('goal_target_date');
+	expect($inner)->not->toHaveKey('goal_needs_whole_amount');
 });
 
 // ---------------------------------------------------------------------------
@@ -502,6 +505,7 @@ it('CreateCategoryRequest toArray() includes all optional fields when populated'
 		note: 'Weekly food',
 		goalTarget: 30000,
 		goalTargetDate: '2026-12-31',
+		goalNeedsWholeAmount: false,
 	);
 
 	$result = $request->toArray();
@@ -512,6 +516,7 @@ it('CreateCategoryRequest toArray() includes all optional fields when populated'
 		'note' => 'Weekly food',
 		'goal_target' => 30000,
 		'goal_target_date' => '2026-12-31',
+		'goal_needs_whole_amount' => false,
 	]);
 });
 
@@ -523,6 +528,7 @@ it('CreateCategoryRequest toArray() excludes null optional fields inside categor
 	expect($inner)->not->toHaveKey('note');
 	expect($inner)->not->toHaveKey('goal_target');
 	expect($inner)->not->toHaveKey('goal_target_date');
+	expect($inner)->not->toHaveKey('goal_needs_whole_amount');
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Adds `goalNeedsWholeAmount` (nullable bool) to `CreateCategoryRequest` and `UpdateCategoryRequest`, mapping to `goal_needs_whole_amount` in the API payload
- This field controls whether a NEED goal requires the full target amount each period ("Set aside another..." vs "Refill up to...")
- Matches the new `goal_needs_whole_amount` property added to the `SaveCategory` schema in API v1.83.0

## Test plan
- [x] All 97 existing tests pass
- [x] Updated serialization tests cover the new field in both create and update requests
- [x] Verified null exclusion works correctly (field omitted when not set)