### PR TITLE
Make Category internal constructor argument optional for v2.4.0

### DIFF
--- a/src/Model/Category.php
+++ b/src/Model/Category.php
@@ -19,8 +19,8 @@ final readonly class Category implements Model
 		public int $groupOrder,
 		public int $categoryOrder,
 		public bool $hidden,
-		public bool $internal,
 		public bool $deleted,
+		public bool $internal = false,
 	) {
 	}
 

--- a/src/Model/CategoryDetail.php
+++ b/src/Model/CategoryDetail.php
@@ -22,7 +22,6 @@ final readonly class CategoryDetail implements Model
 		public int $activity,
 		public int $balance,
 		public bool $hidden,
-		public bool $internal,
 		public bool $deleted,
 		public ?string $balanceFormatted,
 		public ?float $balanceCurrency,
@@ -39,6 +38,7 @@ final readonly class CategoryDetail implements Model
 		public ?string $goalOverallLeftFormatted,
 		public ?float $goalOverallLeftCurrency,
 		public array $raw,
+		public bool $internal = false,
 	) {
 	}
 

--- a/src/Model/CategoryGroup.php
+++ b/src/Model/CategoryGroup.php
@@ -15,8 +15,8 @@ final readonly class CategoryGroup implements Model
 		public string $id,
 		public string $name,
 		public bool $hidden,
-		public bool $internal,
 		public bool $deleted,
+		public bool $internal = false,
 	) {
 	}
 

--- a/tests/Unit/ModelMappingTest.php
+++ b/tests/Unit/ModelMappingTest.php
@@ -206,6 +206,12 @@ it('defaults category group internal flag to false when missing', function () {
 	expect($group?->internal)->toBeFalse();
 });
 
+it('allows constructing CategoryGroup without the internal argument', function () {
+	$group = new CategoryGroup(id: 'CG1', name: 'Essentials', hidden: false, deleted: false);
+
+	expect($group->internal)->toBeFalse();
+});
+
 it('maps category detail rows into typed objects', function () {
 	$category = CategoryDetail::fromArray([
 		'id' => 'C1',


### PR DESCRIPTION
## Summary

- Move `internal` to the end of the `CategoryGroup`, `Category`, and `CategoryDetail` constructor signatures and default it to `false`.
- Preserves backward compatibility for any caller constructing these readonly models directly, so the v1.84.0 `internal` field catch-up from #26 ships as a true minor release instead of a breaking change.
- `fromArray()` mappers are unaffected — they already use named arguments and continue to populate `internal` from the response payload.

The `internal` parameter should be promoted back to required in the next major release. Tracked separately for v3.0.0.

## Test plan

- [x] `composer test` — 100 passed, 505 assertions (added a regression test asserting `CategoryGroup` constructs without `internal`)